### PR TITLE
Fixing the Era Name test cases on Linux.

### DIFF
--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 
@@ -16,8 +17,11 @@ namespace System.Globalization.Tests
         {
             DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
 
-            VerificationHelper(info, 0, "AD");
-            VerificationHelper(info, 1, "AD");
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            string abbreviatedEraName = isWindows ? "AD" : "A";
+
+            VerificationHelper(info, 0, abbreviatedEraName);
+            VerificationHelper(info, 1, abbreviatedEraName);
         }
 
         // PosTest2: Call GetAbbreviatedEraName to get Era's abbreviated name on instance created from ctor
@@ -61,14 +65,6 @@ namespace System.Globalization.Tests
         {
             string actual = info.GetAbbreviatedEraName(era);
             Assert.Equal(expected, actual);
-        }
-
-        private String Hex(String str)
-        {
-            StringBuilder retValue = new StringBuilder();
-            foreach (Char ch in str)
-                retValue.Append(String.Format("\\u{0:X4}", (int)ch));
-            return retValue.ToString();
         }
     }
 }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -31,10 +32,16 @@ namespace System.Globalization.Tests
         {
             DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
 
-            VerificationHelper(info, "A.D.", 1);
-            VerificationHelper(info, "a.d.", 1);
-            VerificationHelper(info, "AD", 1);
-            VerificationHelper(info, "ad", 1);
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            string eraName = isWindows ? "A.D." : "AD";
+            string lowerEraName = isWindows ? "a.d." : "ad";
+            string abbrevEraName = isWindows ? "AD" : "A";
+            string lowerAbbrevEraName = isWindows ? "ad" : "a";
+
+            VerificationHelper(info, eraName, 1);
+            VerificationHelper(info, lowerEraName, 1);
+            VerificationHelper(info, abbrevEraName, 1);
+            VerificationHelper(info, lowerAbbrevEraName, 1);
 
             VerificationHelper(info, "C.E.", -1);
             VerificationHelper(info, "CE", -1);

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -24,8 +25,12 @@ namespace System.Globalization.Tests
         public void PosTest2()
         {
             DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
-            VerificationHelper(info, 1, "A.D.");
-            VerificationHelper(info, 0, "A.D.");
+
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            string eraName = isWindows ? "A.D." : "AD";
+
+            VerificationHelper(info, 1, eraName);
+            VerificationHelper(info, 0, eraName);
         }
 
         // PosTest3: Call GetEra when DateTimeFormatInfo created from fr-FR


### PR DESCRIPTION
ICU returns "AD" instead of "A.D." for the era name and "A" instead of "AD" for the abbreviated era name.

System.Globalization.Tests now passes successfully on my machine with this change.

@ellismg, @tarekgh, @steveharter 
