### PR TITLE
Enable all the disabled tests that are currently passing.

### DIFF
--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Globalization.Tests
+{
+    internal static class DateTimeFormatInfoData
+    {
+        private static bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static string GetEraName(CultureInfo cultureInfo)
+        {
+            if (string.Equals(cultureInfo.Name, "en-US", StringComparison.OrdinalIgnoreCase))
+            {
+                return s_isWindows ? "A.D." : "AD";
+            }
+            if (string.Equals(cultureInfo.Name, "fr-FR", StringComparison.OrdinalIgnoreCase))
+            {
+                return "ap. J.-C.";
+            }
+
+            throw GetCultureNotSupportedException(cultureInfo);
+        }
+
+        public static string GetAbbreviatedEraName(CultureInfo cultureInfo)
+        {
+            if (string.Equals(cultureInfo.Name, "en-US", StringComparison.OrdinalIgnoreCase))
+            {
+                return s_isWindows ? "AD" : "A";
+            }
+            if (string.Equals(cultureInfo.Name, "ja-JP", StringComparison.OrdinalIgnoreCase) &&
+                cultureInfo.Calendar.GetType() == typeof(GregorianCalendar))
+            {
+                //For Windows<Win7 and others, the default calendar is Gregorian Calendar, AD is expected to be the Era Name
+                // CLDR has the Japanese abbreviated era name for the Gregorian Calendar in English - "AD",
+                // so for non-Windows machines it will be "AD".
+                return s_isWindows ? "\u897F\u66A6" : "AD";
+            }
+
+            throw GetCultureNotSupportedException(cultureInfo);
+        }
+
+        private static Exception GetCultureNotSupportedException(CultureInfo cultureInfo)
+        {
+            return new NotSupportedException(string.Format("The culture '{0}' with calendar '{1}' is not supported.", 
+                cultureInfo.Name, 
+                cultureInfo.Calendar.GetType().Name));
+        }
+    }
+}

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
@@ -46,7 +46,6 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
@@ -11,14 +11,15 @@ namespace System.Globalization.Tests
 {
     public class DateTimeFormatInfoGetAbbreviatedEraName
     {
+        private static bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
         // PosTest1: Call GetAbbreviatedEraName to get Era's abbreviated name
         [Fact]
         public void PosTest1()
         {
             DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
 
-            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            string abbreviatedEraName = isWindows ? "AD" : "A";
+            string abbreviatedEraName = s_isWindows ? "AD" : "A";
 
             VerificationHelper(info, 0, abbreviatedEraName);
             VerificationHelper(info, 1, abbreviatedEraName);
@@ -36,12 +37,14 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call GetAbbreviatedEraName to get Era's abbreviated name on ja-JP culture
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("ja-JP").DateTimeFormat;
             //For Windows<Win7 and others, the default calendar is Gregorian Calendar, AD is expected to be the Era Name
-            String expectedEraName = "\u897F\u66A6";
+            // CLDR has the Japanese abbreviated era name for the Gregorian Calendar in English - "AD",
+            // so for non-Windows machines it will be "AD".
+            String expectedEraName = s_isWindows ? "\u897F\u66A6" : "AD";
+
             VerificationHelper(info, 1, expectedEraName);
         }
 

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 
@@ -11,15 +10,13 @@ namespace System.Globalization.Tests
 {
     public class DateTimeFormatInfoGetAbbreviatedEraName
     {
-        private static bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
         // PosTest1: Call GetAbbreviatedEraName to get Era's abbreviated name
         [Fact]
         public void PosTest1()
         {
-            DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
-
-            string abbreviatedEraName = s_isWindows ? "AD" : "A";
+            CultureInfo cultureInfo = new CultureInfo("en-us");
+            DateTimeFormatInfo info = cultureInfo.DateTimeFormat;
+            string abbreviatedEraName = DateTimeFormatInfoData.GetAbbreviatedEraName(cultureInfo);
 
             VerificationHelper(info, 0, abbreviatedEraName);
             VerificationHelper(info, 1, abbreviatedEraName);
@@ -39,11 +36,9 @@ namespace System.Globalization.Tests
         [Fact]
         public void PosTest3()
         {
-            DateTimeFormatInfo info = new CultureInfo("ja-JP").DateTimeFormat;
-            //For Windows<Win7 and others, the default calendar is Gregorian Calendar, AD is expected to be the Era Name
-            // CLDR has the Japanese abbreviated era name for the Gregorian Calendar in English - "AD",
-            // so for non-Windows machines it will be "AD".
-            String expectedEraName = s_isWindows ? "\u897F\u66A6" : "AD";
+            CultureInfo cultureInfo = new CultureInfo("ja-JP");
+            DateTimeFormatInfo info = cultureInfo.DateTimeFormat;
+            string expectedEraName = DateTimeFormatInfoData.GetAbbreviatedEraName(cultureInfo);
 
             VerificationHelper(info, 1, expectedEraName);
         }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
@@ -64,7 +64,6 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
@@ -47,7 +47,6 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -30,13 +29,13 @@ namespace System.Globalization.Tests
         [Fact]
         public void TestEnUS()
         {
-            DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
+            CultureInfo cultureInfo = new CultureInfo("en-us");
+            DateTimeFormatInfo info = cultureInfo.DateTimeFormat;
 
-            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            string eraName = isWindows ? "A.D." : "AD";
-            string lowerEraName = isWindows ? "a.d." : "ad";
-            string abbrevEraName = isWindows ? "AD" : "A";
-            string lowerAbbrevEraName = isWindows ? "ad" : "a";
+            string eraName = DateTimeFormatInfoData.GetEraName(cultureInfo);
+            string lowerEraName = eraName.ToLower();
+            string abbrevEraName = DateTimeFormatInfoData.GetAbbreviatedEraName(cultureInfo);
+            string lowerAbbrevEraName = abbrevEraName.ToLower();
 
             VerificationHelper(info, eraName, 1);
             VerificationHelper(info, lowerEraName, 1);

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
@@ -52,7 +52,6 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call GetEra when DateTimeFormatInfo created from fr-FR
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void TestFrFR()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -20,33 +19,19 @@ namespace System.Globalization.Tests
             VerificationHelper(info, 0, "A.D.");
         }
 
-        // PosTest2: Call GetEra when DateTimeFormatInfo from en-us culture
-        [Fact]
-        public void PosTest2()
+        // PosTest2: Call GetEra when DateTimeFormatInfo from en-us and fr-FR cultures
+        [Theory]
+        [InlineData("en-us")]
+        [InlineData("fr-FR")]
+        public void PosTest2(string localeName)
         {
-            DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
-
-            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            string eraName = isWindows ? "A.D." : "AD";
+            CultureInfo cultureInfo = new CultureInfo(localeName);
+            DateTimeFormatInfo info = cultureInfo.DateTimeFormat;
+            string eraName = DateTimeFormatInfoData.GetEraName(cultureInfo);
 
             VerificationHelper(info, 1, eraName);
             VerificationHelper(info, 0, eraName);
         }
-
-        // PosTest3: Call GetEra when DateTimeFormatInfo created from fr-FR
-        [Fact]
-        public void PosTest3()
-        {
-            DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;
-
-            // For Win7, "fr-FR" is "ap J.-C".
-            // for windows<Win7 & MAC, every culture is "A.D."
-            String expectedRetValue = "ap. J.-C.";
-
-            VerificationHelper(info, 1, expectedRetValue);
-            VerificationHelper(info, 0, expectedRetValue);
-        }
-
 
         // NegTest1: ArgumentOutOfRangeException should be thrown when era does not represent a valid era in the calendar specified in the Calendar property
         [Fact]

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
@@ -35,7 +35,6 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call GetEra when DateTimeFormatInfo created from fr-FR
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
@@ -64,7 +64,6 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthGenitiveNames.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthGenitiveNames.cs
@@ -58,7 +58,6 @@ namespace System.Globalization.Tests
 
         // PosTest3: Call MonthGenitiveNames getter method should return correct value for ru-ru culture
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void TestRuCulture()
         {
             DateTimeFormatInfo info = new CultureInfo("ru-RU").DateTimeFormat;
@@ -139,16 +138,6 @@ namespace System.Globalization.Tests
             string[] actual = info.MonthGenitiveNames;
             Assert.Equal(expected.Length, actual.Length);
             Assert.Equal(expected, actual);
-        }
-
-        private String Hex(String str)
-        {
-            StringBuilder retValue = new StringBuilder();
-            foreach (Char ch in str)
-            {
-                retValue.Append(String.Format("\\u{0:X4}", (int)ch));
-            }
-            return retValue.ToString();
         }
     }
 }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoYearMonthPattern.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoYearMonthPattern.cs
@@ -13,7 +13,6 @@ namespace System.Globalization.Tests
 
         // PosTest1: Call YearMonthPattern getter method should return correct value for InvariantInfo
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void TestGetter()
         {
             VerificationHelper(DateTimeFormatInfo.InvariantInfo, "yyyy MMMM", false);

--- a/src/System.Globalization/tests/RegionInfo/regioninfo.cs
+++ b/src/System.Globalization/tests/RegionInfo/regioninfo.cs
@@ -10,7 +10,6 @@ namespace System.Globalization.Tests
     public class RegionInfoTest
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test1()
         {
             RegionInfo riUS = new RegionInfo("en-US");
@@ -19,7 +18,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test2()
         {
             RegionInfo riUS = new RegionInfo("en-US");

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <Compile Include="CompareInfo.cs" />
     <Compile Include="CompareInfo.TestData.cs" />
+    <Compile Include="DateTimeFormatInfo\DateTimeFormatInfoData.cs" />
     <Compile Include="NumberFormatInfo\NumberFormatInfoNumberDecimalDigits.cs" />
     <Compile Include="NumberFormatInfo\NumberFormatInfoNumberNegativePattern.cs" />
     <Compile Include="NumberFormatInfo\NumberFormatInfoPercentNegativePattern.cs" />

--- a/src/System.Globalization/tests/TextInfo/TextInfoEquals.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoEquals.cs
@@ -25,7 +25,6 @@ namespace System.Globalization.Tests
 
         // PosTest2: Verify the TextInfo is not same CultureInfo's
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void TestDiffCultureTextInfo()
         {
             TextInfo textInfoFrance = new CultureInfo("fr-FR").TextInfo;

--- a/src/System.Globalization/tests/TextInfo/TextInfoGetHashCode.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoGetHashCode.cs
@@ -24,7 +24,6 @@ namespace System.Globalization.Tests
 
         // PosTest2: Verify the TextInfo is not same  CultureInfo's
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void TestFrFRGetHashCode()
         {
             TextInfo textInfoFrance = new CultureInfo("fr-FR").TextInfo;

--- a/src/System.Globalization/tests/TextInfo/TextInfoToLower.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoToLower.cs
@@ -73,7 +73,6 @@ namespace System.Globalization.Tests
 
         // PosTest6: uppercase character for Turkish Culture
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void TestTrTRUppercaseCharacter()
         {
             char ch = '\u0130';

--- a/src/System.Globalization/tests/TextInfo/TextInfoToUpper1.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoToUpper1.cs
@@ -85,7 +85,6 @@ namespace System.Globalization.Tests
 
         // PosTest7: lowercase character for Turkish Culture
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void TestTrTRLowercaseCharacter()
         {
             char ch = 'i';

--- a/src/System.Globalization/tests/TextInfo/TextInfoToUpper2.cs
+++ b/src/System.Globalization/tests/TextInfo/TextInfoToUpper2.cs
@@ -73,7 +73,6 @@ namespace System.Globalization.Tests
 
         // PosTest6: normal string ToUpper and TextInfo is Turkish CultureInfo's
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void TestTrTRNormalString()
         {
             string strA = "H\u0131!";
@@ -87,7 +86,6 @@ namespace System.Globalization.Tests
 
         // PosTest7: normal string with special symbols and TextInfo is Turkish CultureInfo's
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void TestTrTRStringWithSymbols()
         {
             string strA = "H\u0131\n\0Hi\u0009!";


### PR DESCRIPTION
Only one test needed to be "fixed" up - Japanese Abbreviated Era Name is different between Windows and CLDR.
