### PR TITLE
Enable all tests in Globalization.Calendar.Tests.

### DIFF
--- a/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarAddMonths.cs
+++ b/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarAddMonths.cs
@@ -13,7 +13,6 @@ namespace System.Globalization.CalendarsTests
         #region Positive Test Cases
         // PosTest1: Call AddMonths to add valid value
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest1()
         {
             System.Globalization.Calendar calendar = new JapaneseCalendar();
@@ -29,7 +28,6 @@ namespace System.Globalization.CalendarsTests
 
         // PosTest2: Call AddMonths to add boundary value
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest2()
         {
             System.Globalization.Calendar calendar = new JapaneseCalendar();
@@ -44,7 +42,6 @@ namespace System.Globalization.CalendarsTests
 
         // PosTest3: Call AddMonths to add month when the day is not in the month
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest3()
         {
             System.Globalization.Calendar calendar = new JapaneseCalendar();

--- a/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarEras.cs
+++ b/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarEras.cs
@@ -15,7 +15,6 @@ namespace System.Globalization.CalendarsTests
 
         #region Positive Test Cases
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest1()
         {
             int[] actual = new JapaneseCalendar().Eras;

--- a/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarMaxSupportedDateTime.cs
+++ b/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarMaxSupportedDateTime.cs
@@ -12,7 +12,6 @@ namespace System.Globalization.CalendarsTests
         #region Positive Test Cases
         // PosTest1: Call MaxSupportedDateTime to get max supported date time
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest1()
         {
             DateTime actual = new JapaneseCalendar().MaxSupportedDateTime;

--- a/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarMinSupportedDateTime.cs
+++ b/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarMinSupportedDateTime.cs
@@ -12,7 +12,6 @@ namespace System.Globalization.CalendarsTests
         #region Positive Test Cases
         // PosTest1: Call MinSupportedDateTime to get max supported date time
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest1()
         {
             DateTime actual = new JapaneseCalendar().MinSupportedDateTime;

--- a/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarTwoDigitYearMax.cs
+++ b/src/System.Globalization.Calendars/tests/JapaneseCalendar/JapaneseCalendarTwoDigitYearMax.cs
@@ -12,7 +12,6 @@ namespace System.Globalization.CalendarsTests
         #region Positive Test Cases
         // PosTest1: Call TwoDigitYearMax to get max supported date time
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest1()
         {
             int actual = new JapaneseCalendar().TwoDigitYearMax;
@@ -22,7 +21,6 @@ namespace System.Globalization.CalendarsTests
 
         // PosTest2: Call TwoDigitYearMax to get max supported date time
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest2()
         {
             int expected = 200;

--- a/src/System.Globalization.Calendars/tests/Misc/Calendars.cs
+++ b/src/System.Globalization.Calendars/tests/Misc/Calendars.cs
@@ -52,7 +52,6 @@ namespace System.Globalization.CalendarsTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void JapaneseTest()
         {
             JapaneseCalendar cal = new JapaneseCalendar();
@@ -60,7 +59,6 @@ namespace System.Globalization.CalendarsTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void JapaneseLunisolarTest()
         {
             JapaneseLunisolarCalendar cal = new JapaneseLunisolarCalendar();

--- a/src/System.Globalization.Calendars/tests/Misc/MiscCalendars.cs
+++ b/src/System.Globalization.Calendars/tests/Misc/MiscCalendars.cs
@@ -46,7 +46,6 @@ namespace System.Globalization.CalendarsTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void JapaneseTest()
         {
             JapaneseCalendar jCal = new JapaneseCalendar();

--- a/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarDaysAndMonths.cs
+++ b/src/System.Globalization.Calendars/tests/TaiwanCalendar/TaiwanCalendarDaysAndMonths.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Globalization.CalendarsTests
@@ -10,12 +11,20 @@ namespace System.Globalization.CalendarsTests
     public class TaiwanCalendarDaysAndMonths
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test1()
         {
-            string[] edays = { "\u661F\u671F\u65E5", "\u661F\u671F\u4E00", "\u661F\u671F\u4E8C", "\u661F\u671F\u4E09", "\u661F\u671F\u56DB", "\u661F\u671F\u4E94", "\u661F\u671F\u516D" };
-            string[] emonths = { "\u4E00\u6708", "\u4E8C\u6708", "\u4E09\u6708", "\u56DB\u6708", "\u4E94\u6708", "\u516D\u6708", "\u4E03\u6708",
-                             "\u516B\u6708", "\u4E5D\u6708", "\u5341\u6708", "\u5341\u4E00\u6708", "\u5341\u4E8C\u6708", "" };
+            string[] edays = {
+                "\u661F\u671F\u65E5",
+                "\u661F\u671F\u4E00",
+                "\u661F\u671F\u4E8C",
+                "\u661F\u671F\u4E09",
+                "\u661F\u671F\u56DB",
+                "\u661F\u671F\u4E94",
+                "\u661F\u671F\u516D"
+            };
+
+            string[] emonths = GetMonthNames();
+
             DateTimeFormatInfo dtfi = new CultureInfo("zh-TW").DateTimeFormat;
             dtfi.Calendar = new TaiwanCalendar();
 
@@ -30,6 +39,47 @@ namespace System.Globalization.CalendarsTests
             for (int i = 0; i < edays.Length; i++)
             {
                 Assert.Equal(emonths[i], amonths[i]);
+            }
+        }
+
+        private static string[] GetMonthNames()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return new string[] {
+                    "\u4E00\u6708",
+                    "\u4E8C\u6708",
+                    "\u4E09\u6708",
+                    "\u56DB\u6708",
+                    "\u4E94\u6708",
+                    "\u516D\u6708",
+                    "\u4E03\u6708",
+                    "\u516B\u6708",
+                    "\u4E5D\u6708",
+                    "\u5341\u6708",
+                    "\u5341\u4E00\u6708",
+                    "\u5341\u4E8C\u6708",
+                    string.Empty,
+                };
+            }
+            else
+            {
+                // CLDR has a digit followed by the month symbol for the month names
+                return new string[] {
+                    "1\u6708",
+                    "2\u6708",
+                    "3\u6708",
+                    "4\u6708",
+                    "5\u6708",
+                    "6\u6708",
+                    "7\u6708",
+                    "8\u6708",
+                    "9\u6708",
+                    "10\u6708",
+                    "11\u6708",
+                    "12\u6708",
+                    string.Empty,
+                };
             }
         }
     }


### PR DESCRIPTION
Only one test needed to be fixed up - Taiwan month names are different in CLDR than they are on Windows.

@ellismg, @tarekgh, @steveharter 
